### PR TITLE
Fix/dashboard left panel overlap

### DIFF
--- a/client/src/components/dashboard-nav.tsx
+++ b/client/src/components/dashboard-nav.tsx
@@ -64,7 +64,7 @@ export function DashboardNav({
 
   return (
     <>
-      <nav className="flex flex-col items-center mt-16 gap-4 px-2 sm:py-5">
+      <nav className="flex flex-col items-center  gap-4 px-2 sm:py-5">
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>

--- a/client/src/components/dashboard.tsx
+++ b/client/src/components/dashboard.tsx
@@ -96,7 +96,7 @@ export function Dashboard() {
   return (
     <div className="flex min-h-screen w-full flex-col bg-muted/40 pt-16 overflow-x-hidden">
       {/* Desktop Sidebar */}
-      <aside className="fixed inset-y-0 left-0 hidden w-14 flex-col border-r bg-background sm:flex z-30">
+      <aside className="fixed top-16 bottom-0 left-0 hidden w-14 flex-col border-r bg-background sm:flex z-30">
         <DashboardNav activeTab={activeTab} handleTabChange={handleTabChange} />
       </aside>
 


### PR DESCRIPTION
### Layout and Styling Adjustments:

* [`client/src/components/dashboard-nav.tsx`](diffhunk://#diff-904b684535c1c2de69a97768b494162981700645f091bd57db7814b40504e732L67-R67): Removed an unnecessary `mt-16` class from the `<nav>` element in `DashboardNav` to adjust vertical spacing.
* [`client/src/components/dashboard.tsx`](diffhunk://#diff-eeeb61d5d7dfd243b8ab0315b2812398310cd355f9f68227b517ce35913c8631L99-R99): Updated the `<aside>` element in `Dashboard` to use `top-16 bottom-0` instead of `inset-y-0` for more precise positioning within the viewport.